### PR TITLE
Fix pubspec dependency conflict by removing intl package from pubspec

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -211,12 +211,12 @@ packages:
     source: hosted
     version: "0.2.3"
   intl:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.16.1"
+    version: "0.16.0"
   location_permissions:
     dependency: transitive
     description:
@@ -272,7 +272,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.0+1"
   permission_handler:
     dependency: "direct main"
     description:
@@ -410,7 +410,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.11"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,6 @@ dependencies:
   flutter_background_geolocation: ^1.7.0
   dio: ^3.0.9
   google_maps_flutter: ^0.5.25+1
-  intl: ^0.16.1
   url_launcher: ^5.4.2
   firebase_remote_config: ^0.3.0+3
   # The following adds the Cupertino Icons font to your application.
@@ -70,11 +69,11 @@ flutter:
     - assets/locales/es.json
 
   fonts:
-     - family: Montserrat
-       fonts:
-         - asset: fonts/Montserrat-Regular.ttf
-         - asset: fonts/Montserrat-Bold.ttf
-           weight: 700
+    - family: Montserrat
+      fonts:
+        - asset: fonts/Montserrat-Regular.ttf
+        - asset: fonts/Montserrat-Bold.ttf
+          weight: 700
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
Fixing a master build error because the dependency versions do not match.

```bash
== Install Flutter dependencies ==

> /usr/local/bin/flutter packages pub get

Resolving dependencies...

Because corona_trace depends on flutter_localizations any from sdk which depends on intl 0.16.0, intl 0.16.0 is required.
So, because corona_trace depends on intl ^0.16.1, version solving failed.
pub finished with exit code 1
```